### PR TITLE
Remove trailing slash

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mickael-kerjean/net/
+module github.com/mickael-kerjean/net
 
 require (
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2


### PR DESCRIPTION
Hi @mickael-kerjean, I'm debugging https://github.com/mickael-kerjean/filestash/issues/200 and in the process, I setup go.mod in filestash to pull in all the deps.

In the process, when I ran
```
go mod download
make
```

It threw this error: 
```
go: github.com/mickael-kerjean/filestash/server/ctrl imports
	github.com/mickael-kerjean/net/webdav: github.com/mickael-kerjean/net@v0.0.0-20190828100839-4816879ec04b: parsing go.mod:
	module declares its path as: github.com/mickael-kerjean/net/
	        but was required as: github.com/mickael-kerjean/net
make[1]: *** [build_backend] Error 1
make: *** [all] Error 2
```

Comparing your go.mod to the official `net` repo, the fix looks like it could be removing the trailing slash here.

Cheers.